### PR TITLE
Class to grab NST and modificaiton to Habi Bot

### DIFF
--- a/cache/default.cfg
+++ b/cache/default.cfg
@@ -50,7 +50,7 @@ autoprice = off
 autoprice_file = ./list/autosell/default.txt
 
 [trainer]
-trainpets = on
+trainpets = off
 trainmode = allpets
 trainstat = level
 maxspeand = 20000

--- a/classes/checkNST.py
+++ b/classes/checkNST.py
@@ -1,0 +1,9 @@
+import time
+
+def getNST(offset):
+    systime = time.strftime("%H%M")
+    intTime = int(systime)
+    intNST = intTime + offset
+    if (intNST > 2400):
+        intNST = intNST - 2400
+    return intNST

--- a/client.py
+++ b/client.py
@@ -36,6 +36,7 @@ from classes.mobileservices import mobileservices
 from classes.nomobileservices import nomobileservices
 from classes.hotel import hotel
 from classes.battle import battle
+from classes.checkNST import getNST
 
 
 
@@ -61,6 +62,8 @@ neouser = "" #Neopets username
 neopass = "" #Neopets password
 neopin = "" #Neopets pin number (if used , leave as "" if not used)
 proxy = "" #localhost:8888 or 123.123.123.123:8080 ect - "" for none
+NSToffset = 700 #How many hours AHEAD of your system time is NST, in format HHMM
+                # e.g. 700 = 7 hours ahead. This stops the habi bot during maintenance hours
 
 if neouser == "":
     #Todo add a user input option here if neouser not set
@@ -224,8 +227,13 @@ while test ==1:
 
 
         if habihander.habi_on == 'on':
-           habihander.DoLoop()
-           time.sleep(30)
+           curNST = getNST(NSToffset)
+           if curNST > 195 and curNST < 405:
+              print "Doing nothing - habi maintenance hours \n"
+              time.sleep(30)
+           else:
+              habihander.DoLoop()
+              time.sleep(30)
 
  #   except:
  #       time.sleep(10)


### PR DESCRIPTION
checkNST class to grab current NST based on systime and a user-given offset

Modified runtime code to stop the Habi Bot during maintenance hours (2am->4am NST)
This should help keep undetected

Offset setting is currently in client.py, should probably be moved to cfg file eventually, if it gets used anywhere else
